### PR TITLE
remove eslint consistent return disable comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,11 +44,11 @@ module.exports = (opts, cb) => {
       overwriteRefused = true;
     }
   });
-  proc.on('exit', () => { // eslint-disable-line consistent-return
+  proc.on('exit', () => {
     if (overwriteRefused) {
       return cb(new Error('Key not generated because it would overwrite an existing file'));
     }
-    fs.readFile(location, { encoding: 'ascii' }, (privateErr, privateKey) => { // eslint-disable-line consistent-return
+    return fs.readFile(location, { encoding: 'ascii' }, (privateErr, privateKey) => {
       if (privateErr && privateErr.code !== 'ENOENT') {
         return cb(privateErr);
       }
@@ -56,7 +56,7 @@ module.exports = (opts, cb) => {
         return cb(new Error(stderr));
       }
       ret.private = privateKey;
-      fs.readFile(`${location}.pub`, { encoding: 'ascii' }, (publicErr, publicKey) => { // eslint-disable-line consistent-return
+      return fs.readFile(`${location}.pub`, { encoding: 'ascii' }, (publicErr, publicKey) => {
         if (publicErr && publicErr.code !== 'ENOENT') {
           return cb(publicErr);
         }
@@ -73,15 +73,15 @@ module.exports = (opts, cb) => {
         if (opts.keep) {
           return cb(null, ret);
         }
-        fs.unlink(location, (unlinkPrivateErr) => { // eslint-disable-line consistent-return
+        return fs.unlink(location, (unlinkPrivateErr) => {
           if (unlinkPrivateErr) {
             return cb(unlinkPrivateErr);
           }
-          fs.unlink(`${location}.pub`, (unlinkPublicErr) => { // eslint-disable-line consistent-return
+          return fs.unlink(`${location}.pub`, (unlinkPublicErr) => {
             if (unlinkPublicErr) {
               return cb(unlinkPublicErr);
             }
-            cb(null, ret);
+            return cb(null, ret);
           });
         });
       });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -74,7 +74,7 @@ describe('basic tests', () => {
       expect(expect(err).to.be.null);
       expect(expect(result.path).to.not.be.null);
       const privateKey = result.private;
-      fs.readFile(result.path, { encoding: 'ascii' }, (fileReadErr, key) => { // eslint-disable-line consistent-return
+      fs.readFile(result.path, { encoding: 'ascii' }, (fileReadErr, key) => {
         expect(expect(fileReadErr).to.be.null);
         expect(key).to.match(/^-----BEGIN RSA PRIVATE KEY-----\n/);
         expect(key).to.eql(privateKey);
@@ -90,7 +90,7 @@ describe('basic tests', () => {
       expect(expect(err).to.be.null);
       expect(expect(result.path).to.be.undefined);
       expect(result.private).to.match(/^-----BEGIN RSA PRIVATE KEY-----\n/);
-      fs.readFile(dummyLocation, { encoding: 'ascii' }, (fileReadErr, _) => { // eslint-disable-line consistent-return
+      fs.readFile(dummyLocation, { encoding: 'ascii' }, (fileReadErr, _) => {
         expect(expect(fileReadErr).to.not.be.null);
         expect(fileReadErr.code).to.eql('ENOENT');
         done();


### PR DESCRIPTION
**Summary**

- removed all `//eslint-disable-line consistent-return` comments
- refactored code so that eslint rule will be satisfied

Fixes https://github.com/AndrewLane/ssh-keygen2/issues/43