### PR TITLE
Fix import order linting failure

### DIFF
--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,9 +1,9 @@
+const fs = require('fs');
 const { expect } = require('chai');
 const { describe, it } = require('mocha');
 const tmpDir = require('os').tmpdir();
 const path = require('path');
 const crypto = require('crypto');
-const fs = require('fs');
 const keygen = require('..');
 
 describe('basic tests', () => {


### PR DESCRIPTION
Trying to fix:
```
Error:   1:20  error  `chai` import should occur after import of `fs`   import/order
Error:   2:26  error  `mocha` import should occur after import of `fs`  import/order
```